### PR TITLE
Bugfix username and password in generic template

### DIFF
--- a/src/main/resources/templates/plugins/generic/editArtifactoryGenericBuildAction.ftl
+++ b/src/main/resources/templates/plugins/generic/editArtifactoryGenericBuildAction.ftl
@@ -59,8 +59,8 @@
     var errorDiv = document.getElementById('artifactory-error');
     function displayGenericArtifactoryConfigs(serverId) {
         var configDiv = document.getElementById('genericArtifactoryConfigDiv');
-        var credentialsUserName = configDiv.getElementsByTagName('input')[1].value;
-        var credentialsPassword = configDiv.getElementsByTagName('input')[2].value;
+        var credentialsUserName = configDiv.getElementsByName('artifactory.generic.username')[0].value;
+        var credentialsPassword = configDiv.getElementsByName('artifactory.generic.password')[0].value;
 
         if ((serverId == null) || (serverId.length == 0) || (-1 == serverId)) {
             configDiv.style.display = 'none';


### PR DESCRIPTION
Fixed a bug where the wrong values of inputs were accessed for username and password in the generic template. Incorrectly the value of "artifactory.generic.password" was used as the username and the value of "artifactory.password.DUMMY" was used as the password for the loadGenericRepoKeys request.