### PR TITLE
Fixed repository dropdown menu in task configuration when using varia…

### DIFF
--- a/src/main/resources/templates/plugins/task/editArtifactoryGradleBuilder.ftl
+++ b/src/main/resources/templates/plugins/task/editArtifactoryGradleBuilder.ftl
@@ -40,6 +40,8 @@ listKey='repoKey' listValue='repoKey' toggle='true'/]
 
 [@ww.select name='builder.artifactoryGradleBuilder.publishingRepo' labelKey='artifactory.task.gradle.publishingRepo' list=dummyList
 listKey='repoKey' listValue='repoKey' toggle='true'/]
+<div id="variableAsUserNotificationDiv" class="aui-message aui-message-warning warning shadowed"
+     style="display: none; width: 80%; font-size: 80%" />
 
 [@ww.textfield labelKey='artifactory.task.gradle.deployerUsername' name='builder.artifactoryGradleBuilder.deployerUsername'/]
 
@@ -139,6 +141,19 @@ listKey='repoKey' listValue='repoKey' toggle='true'/]
         var configDiv = document.getElementById('gradleArtifactoryConfigDiv');
         var credentialsUserName = configDiv.getElementsByTagName('input')[2].value;
         var credentialsPassword = configDiv.getElementsByTagName('input')[3].value;
+        
+        var variableExpression = RegExp('\\$\\{bamboo\\..*}');
+        
+        if(variableExpression.test(credentialsUserName) || variableExpression.test(credentialsPassword)){
+			credentialsUserName = "";
+			credentialsPassword = "";
+			
+			var variableMessage = 'The users repositories cannot be loaded when using a variable as username or password. Using globally available repositories instead';
+        	var notificationDiv = document.getElementById('variableAsUserNotificationDiv');
+        	
+        	notificationDiv.innerHTML += variableMessage;
+        	notificationDiv.style.display = '';
+        }
 
         if ((serverId == null) || (serverId.length == 0) || (-1 == serverId)) {
             configDiv.style.display = 'none';

--- a/src/main/resources/templates/plugins/task/editArtifactoryIvyBuilder.ftl
+++ b/src/main/resources/templates/plugins/task/editArtifactoryIvyBuilder.ftl
@@ -24,6 +24,8 @@ listKey='id' listValue='url' onchange='javascript: displayIvyArtifactoryConfigs(
 
 <div id="ivyArtifactoryConfigDiv">
 [@ww.select name='builder.artifactoryIvyBuilder.deployableRepo' labelKey='artifactory.task.maven.targetRepo' list=dummyList listKey='repoKey' listValue='repoKey' toggle='true'/]
+<div id="variableAsUserNotificationDiv" class="aui-message aui-message-warning warning shadowed"
+     style="display: none; width: 80%; font-size: 80%" />
 
 [@ww.textfield labelKey='artifactory.task.maven.deployerUsername' name='builder.artifactoryIvyBuilder.deployerUsername' /]
 
@@ -101,6 +103,19 @@ listKey='id' listValue='url' onchange='javascript: displayIvyArtifactoryConfigs(
         var configDiv = document.getElementById('ivyArtifactoryConfigDiv');
         var credentialsUserName = configDiv.getElementsByTagName('input')[1].value;
         var credentialsPassword = configDiv.getElementsByTagName('input')[2].value;
+        
+        var variableExpression = RegExp('\\$\\{bamboo\\..*}');
+        
+        if(variableExpression.test(credentialsUserName) || variableExpression.test(credentialsPassword)){
+			credentialsUserName = "";
+			credentialsPassword = "";   
+			
+			var variableMessage = 'The users repositories cannot be loaded when using a variable as username or password. Using globally available repositories instead';
+        	var notificationDiv = document.getElementById('variableAsUserNotificationDiv');
+        	
+        	notificationDiv.innerHtml += variableMessage;
+        	notificationDiv.style.display = '';
+        }
 
         if ((serverId == null) || (serverId.length == 0) || (-1 == serverId)) {
             configDiv.style.display = 'none';

--- a/src/main/resources/templates/plugins/task/editArtifactoryMaven3Builder.ftl
+++ b/src/main/resources/templates/plugins/task/editArtifactoryMaven3Builder.ftl
@@ -28,6 +28,8 @@ list=uiConfigBean.getExecutableLabels('maven') extraUtility=addExecutableLink re
 <div id="maven3ArtifactoryResolutionConfigDiv">
     [@ww.select name='builder.artifactoryMaven3Builder.resolutionRepo' labelKey='artifactory.task.maven.resolutionRepo' list=dummyList
     listKey='repoKey' listValue='repoKey' toggle='true' /]
+    <div id="variableAsUserResolutionNotificationDiv" class="aui-message aui-message-warning warning shadowed"
+     style="display: none; width: 80%; font-size: 80%" />
 
 [@ww.textfield labelKey='artifactory.task.maven.resolverUsername' name='builder.artifactoryMaven3Builder.resolverUsername'/]
 
@@ -45,6 +47,8 @@ listKey='id' listValue='url' onchange='javascript: displayMaven3ArtifactoryConfi
 <div id="maven3ArtifactoryConfigDiv">
 [@ww.select name='builder.artifactoryMaven3Builder.deployableRepo' labelKey='artifactory.task.maven.targetRepo' list=dummyList
 listKey='repoKey' listValue='repoKey' toggle='true' /]
+<div id="variableAsUserDeploymentNotificationDiv" class="aui-message aui-message-warning warning shadowed"
+     style="display: none; width: 80%; font-size: 80%" />
 
 [@ww.textfield labelKey='artifactory.task.maven.deployerUsername' name='builder.artifactoryMaven3Builder.deployerUsername' /]
 
@@ -124,7 +128,20 @@ listKey='repoKey' listValue='repoKey' toggle='true' /]
         var configDiv = document.getElementById('maven3ArtifactoryConfigDiv');
         var credentialsUserName = configDiv.getElementsByTagName('input')[1].value;
         var credentialsPassword = configDiv.getElementsByTagName('input')[2].value;
-
+        
+        var variableExpression = RegExp('\\$\\{bamboo\\..*}');
+        
+        if(variableExpression.test(credentialsUserName) || variableExpression.test(credentialsPassword)){
+			credentialsUserName = "";
+			credentialsPassword = "";   
+			
+			var variableMessage = 'The users repositories cannot be loaded when using a variable as username or password. Using globally available repositories instead';
+        	var deploymentNotificationDiv = document.getElementById('variableAsUserDeploymentNotificationDiv');
+        	
+        	deploymentNotificationDiv.innerHTML += variableMessage;
+        	deploymentNotificationDiv.style.display = '';
+        }
+        
         if ((serverId == null) || (serverId.length == 0) || (-1 == serverId)) {
             configDiv.style.display = 'none';
         } else {
@@ -146,6 +163,19 @@ listKey='repoKey' listValue='repoKey' toggle='true' /]
         var configDiv = document.getElementById('maven3ArtifactoryResolutionConfigDiv');
         var credentialsUserName = configDiv.getElementsByTagName('input')[1].value;
         var credentialsPassword = configDiv.getElementsByTagName('input')[2].value;
+        
+        var variableExpression = RegExp('\\$\\{bamboo\\..*}');
+        
+        if(variableExpression.test(credentialsUserName) || variableExpression.test(credentialsPassword)){
+			credentialsUserName = "";
+			credentialsPassword = "";   
+			
+			var variableMessage = 'The users repositories cannot be loaded when using a variable as username or password. Using globally available repositories instead';
+        	var resolutionNotificationDiv = document.getElementById('variableAsUserResolutionNotificationDiv');
+        	
+        	resolutionNotificationDiv.innerHTML += variableMessage;
+        	resolutionNotificationDiv.style.display = '';
+        }
 
         if ((serverId == null) || (serverId.length == 0) || (-1 == serverId)) {
             configDiv.style.display = 'none';


### PR DESCRIPTION
…bles as artifactory user/password

We encountered this problem when using Bamboo global variables containing the artifactory user and password to configure our artifactory build tasks. When using these variables as values in the fields "Override Deployer Username" and "Override Deployer Password" the settings can be saved without problem.

After reopening the configuration of a task it will display this error:
![error](https://user-images.githubusercontent.com/54066559/62944641-6f0c2600-bddd-11e9-9ab8-ec12ca4234f8.PNG)


The plugin currently tries to load the list of available repositories of the user. This is impossible, since the values of global variables, especially those with password information, are not available in the javascript context.

To fix this issue we added a regex test, which makes sure that the input isn't a Bamboo variable. If a variable is used, this warning will now be shown:
![warning](https://user-images.githubusercontent.com/54066559/62944914-f22d7c00-bddd-11e9-8f87-72e9e1b1d620.PNG)


This pull request contains our quick fix for the described problem.  Any other resolution for this error would be appreciated as well.