### PR TITLE
Upgrade build info extractor gradle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
         version and not as a key regarding the Atlassian plugin descriptor -->
         <plugin.key>${project.groupId}.${project.artifactId}-${project.version}</plugin.key>
         <buildinfo.version>2.13.13</buildinfo.version>
-        <buildinfo.maven.version>2.13.11</buildinfo.maven.version>
+        <buildinfo.maven.version>2.13.13</buildinfo.maven.version>
         <buildinfo.gradle.version>4.10.0</buildinfo.gradle.version>
-        <buildinfo.ivy.version>2.13.11</buildinfo.ivy.version>
+        <buildinfo.ivy.version>2.13.13</buildinfo.ivy.version>
     </properties>
     
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <!-- This plugin key is to be used as a unique ID of the plugin incl.
         version and not as a key regarding the Atlassian plugin descriptor -->
         <plugin.key>${project.groupId}.${project.artifactId}-${project.version}</plugin.key>
-        <buildinfo.version>2.13.11</buildinfo.version>
+        <buildinfo.version>2.13.13</buildinfo.version>
         <buildinfo.maven.version>2.13.11</buildinfo.maven.version>
         <buildinfo.gradle.version>4.10.0</buildinfo.gradle.version>
         <buildinfo.ivy.version>2.13.11</buildinfo.ivy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <plugin.key>${project.groupId}.${project.artifactId}-${project.version}</plugin.key>
         <buildinfo.version>2.13.11</buildinfo.version>
         <buildinfo.maven.version>2.13.11</buildinfo.maven.version>
-        <buildinfo.gradle.version>4.9.9</buildinfo.gradle.version>
+        <buildinfo.gradle.version>4.10.0</buildinfo.gradle.version>
         <buildinfo.ivy.version>2.13.11</buildinfo.ivy.version>
     </properties>
     

--- a/src/main/java/org/jfrog/bamboo/builder/GradleInitScriptHelper.java
+++ b/src/main/java/org/jfrog/bamboo/builder/GradleInitScriptHelper.java
@@ -267,6 +267,11 @@ public class GradleInitScriptHelper extends BaseBuildInfoHelper {
         clientConf.publisher.setExcludePatterns(buildContext.getExcludePattern());
         clientConf.publisher.setFilterExcludedArtifactsFromBuild(buildContext.isFilterExcludedArtifactsFromBuild());
         if (publishArtifacts) {
+            try {
+                clientConf.publisher.setPublishForkCount(Integer.parseInt(buildContext.getPublishForkCount()));
+            } catch (NumberFormatException ignore) {
+                log.warn("Illegal 'publishForkCount' value:'" + buildContext.getPublishForkCount() + "'. Keeping default value.");
+            }
             boolean m2Compatible = buildContext.isMaven2Compatible();
             clientConf.publisher.setM2Compatible(m2Compatible);
             if (!m2Compatible) {

--- a/src/main/java/org/jfrog/bamboo/builder/GradleInitScriptHelper.java
+++ b/src/main/java/org/jfrog/bamboo/builder/GradleInitScriptHelper.java
@@ -267,11 +267,7 @@ public class GradleInitScriptHelper extends BaseBuildInfoHelper {
         clientConf.publisher.setExcludePatterns(buildContext.getExcludePattern());
         clientConf.publisher.setFilterExcludedArtifactsFromBuild(buildContext.isFilterExcludedArtifactsFromBuild());
         if (publishArtifacts) {
-            try {
-                clientConf.publisher.setPublishForkCount(Integer.parseInt(buildContext.getPublishForkCount()));
-            } catch (NumberFormatException ignore) {
-                log.warn("Illegal 'publishForkCount' value:'" + buildContext.getPublishForkCount() + "'. Keeping default value.");
-            }
+            clientConf.publisher.setPublishForkCount(buildContext.getPublishForkCount());
             boolean m2Compatible = buildContext.isMaven2Compatible();
             clientConf.publisher.setM2Compatible(m2Compatible);
             if (!m2Compatible) {

--- a/src/main/java/org/jfrog/bamboo/configuration/ArtifactoryGradleConfiguration.java
+++ b/src/main/java/org/jfrog/bamboo/configuration/ArtifactoryGradleConfiguration.java
@@ -44,6 +44,7 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
         context.put("builder.artifactoryGradleBuilder.gitReleaseBranch", "REL-BRANCH-");
         context.put("artifactory.vcs.git.vcs.type.list", getVcsTypes());
         context.put("artifactory.vcs.git.authenticationType.list", getGitAuthenticationTypes());
+        context.put("publishForkCount", "8");
     }
 
     @Override
@@ -70,6 +71,7 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
         }
         context.put("artifactory.vcs.git.vcs.type.list", getVcsTypes());
         context.put("artifactory.vcs.git.authenticationType.list", getGitAuthenticationTypes());
+        context.put("publishForkCount", buildContext.getPublishForkCount());
     }
 
     @NotNull

--- a/src/main/java/org/jfrog/bamboo/configuration/ArtifactoryGradleConfiguration.java
+++ b/src/main/java/org/jfrog/bamboo/configuration/ArtifactoryGradleConfiguration.java
@@ -4,14 +4,18 @@ import com.atlassian.bamboo.collections.ActionParametersMap;
 import com.atlassian.bamboo.plan.Plan;
 import com.atlassian.bamboo.task.TaskDefinition;
 import com.atlassian.bamboo.v2.build.agent.capability.CapabilityDefaultsHelper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jfrog.bamboo.context.AbstractBuildContext;
 import org.jfrog.bamboo.context.GradleBuildContext;
 
+import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Configuration for {@link org.jfrog.bamboo.task.ArtifactoryGradleTask}
@@ -22,6 +26,10 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
     public static final String KEY = "artifactoryGradleBuilder";
     protected static final String DEFAULT_TEST_REPORTS_XML = "**/build/test-results/*.xml";
     private static final Set<String> FIELDS_TO_COPY = GradleBuildContext.getFieldsToCopy();
+    private static final String PUBLISH_FORK_COUNT_OPTIONS_KEY = "publishForkCountList";
+    private static final List<Integer> PUBLISH_FORK_COUNT_OPTIONS = ImmutableList.of(1, 2, 4, 8);
+    private static final String PUBLISH_FORK_COUNT_KEY = "publishForkCount";
+
     public ArtifactoryGradleConfiguration() {
         super(GradleBuildContext.PREFIX, CapabilityDefaultsHelper.CAPABILITY_BUILDER_PREFIX + ".gradle");
     }
@@ -44,7 +52,8 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
         context.put("builder.artifactoryGradleBuilder.gitReleaseBranch", "REL-BRANCH-");
         context.put("artifactory.vcs.git.vcs.type.list", getVcsTypes());
         context.put("artifactory.vcs.git.authenticationType.list", getGitAuthenticationTypes());
-        context.put("publishForkCount", "8");
+        context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_OPTIONS_KEY, getPublishForkCountList());
+        context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_KEY, getDefaultPublishForkCount());
     }
 
     @Override
@@ -71,7 +80,8 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
         }
         context.put("artifactory.vcs.git.vcs.type.list", getVcsTypes());
         context.put("artifactory.vcs.git.authenticationType.list", getGitAuthenticationTypes());
-        context.put("publishForkCount", buildContext.getPublishForkCount());
+        context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_OPTIONS_KEY, getPublishForkCountList());
+        context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_KEY, buildContext.getPublishForkCount());
     }
 
     @NotNull
@@ -108,5 +118,17 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
     @Override
     public boolean taskProducesTestResults(@NotNull TaskDefinition definition) {
         return new GradleBuildContext(definition.getConfiguration()).isTestChecked();
+    }
+
+    private List<String> getPublishForkCountList() {
+        return PUBLISH_FORK_COUNT_OPTIONS.stream()
+                .map(String::valueOf)
+                .collect(Collectors.toList());
+    }
+
+    private String getDefaultPublishForkCount() {
+        return String.valueOf(PUBLISH_FORK_COUNT_OPTIONS.stream()
+                .mapToInt(v -> v)
+                .max().orElseThrow(NoSuchElementException::new));
     }
 }

--- a/src/main/java/org/jfrog/bamboo/context/GradleBuildContext.java
+++ b/src/main/java/org/jfrog/bamboo/context/GradleBuildContext.java
@@ -61,8 +61,8 @@ public class GradleBuildContext extends AbstractBuildContext {
         return env.get(PREFIX + GRADLE_WRAPPER_LOCATION_PARAM);
     }
 
-    public String getPublishForkCount() {
-        return env.get(PREFIX + PUBLISH_FORK_COUNT);
+    public int getPublishForkCount() {
+        return Integer.parseInt(env.get(PREFIX + PUBLISH_FORK_COUNT));
     }
 
     public static GradleBuildContext createGradleContextFromMap(Map<String, Object> map) {

--- a/src/main/java/org/jfrog/bamboo/context/GradleBuildContext.java
+++ b/src/main/java/org/jfrog/bamboo/context/GradleBuildContext.java
@@ -19,7 +19,7 @@ public class GradleBuildContext extends AbstractBuildContext {
     public static final String BUILD_FILE_PARAM = "buildFile";
     public static final String USE_GRADLE_WRAPPER_PARAM = "useGradleWrapper";
     public static final String GRADLE_WRAPPER_LOCATION_PARAM = "gradleWrapperLocation";
-    public static final String PUBLISH_FORK_COUNT = "publishForkCount";
+    public static final String PUBLISH_FORK_COUNT_PARAM = "publishForkCount";
 
     public GradleBuildContext(Map<String, String> env) {
         super(PREFIX, env);
@@ -62,7 +62,7 @@ public class GradleBuildContext extends AbstractBuildContext {
     }
 
     public int getPublishForkCount() {
-        return Integer.parseInt(env.get(PREFIX + PUBLISH_FORK_COUNT));
+        return Integer.parseInt(env.get(PREFIX + PUBLISH_FORK_COUNT_PARAM));
     }
 
     public static GradleBuildContext createGradleContextFromMap(Map<String, Object> map) {
@@ -91,7 +91,7 @@ public class GradleBuildContext extends AbstractBuildContext {
                 RUN_LICENSE_CHECKS, PREFIX + LICENSE_VIOLATION_RECIPIENTS,
                 PREFIX + LIMIT_CHECKS_TO_THE_FOLLOWING_SCOPES, PREFIX + ENVIRONMENT_VARIABLES,
                 PREFIX + INCLUDE_PUBLISHED_ARTIFACTS, PREFIX + DISABLE_AUTOMATIC_LICENSE_DISCOVERY,
-                PUBLISH_ARTIFACTS_PARAM, PREFIX + PUBLISH_FORK_COUNT, PREFIX + PUBLISH_MAVEN_DESCRIPTORS_PARAM,
+                PUBLISH_ARTIFACTS_PARAM, PREFIX + PUBLISH_FORK_COUNT_PARAM, PREFIX + PUBLISH_MAVEN_DESCRIPTORS_PARAM,
                 PREFIX + PUBLISH_IVY_DESCRIPTORS_PARAM, USE_M2_COMPATIBLE_PATTERNS_PARAM,
                 PREFIX + IVY_PATTERN_PARAM, PREFIX + JDK, PREFIX + ARTIFACT_PATTERN_PARAM,
                 PREFIX + PUBLISH_INCLUDE_PATTERNS_PARAM, PREFIX + PUBLISH_EXCLUDE_PATTERNS_PARAM,

--- a/src/main/java/org/jfrog/bamboo/context/GradleBuildContext.java
+++ b/src/main/java/org/jfrog/bamboo/context/GradleBuildContext.java
@@ -19,6 +19,7 @@ public class GradleBuildContext extends AbstractBuildContext {
     public static final String BUILD_FILE_PARAM = "buildFile";
     public static final String USE_GRADLE_WRAPPER_PARAM = "useGradleWrapper";
     public static final String GRADLE_WRAPPER_LOCATION_PARAM = "gradleWrapperLocation";
+    public static final String PUBLISH_FORK_COUNT = "publishForkCount";
 
     public GradleBuildContext(Map<String, String> env) {
         super(PREFIX, env);
@@ -60,6 +61,10 @@ public class GradleBuildContext extends AbstractBuildContext {
         return env.get(PREFIX + GRADLE_WRAPPER_LOCATION_PARAM);
     }
 
+    public String getPublishForkCount() {
+        return env.get(PREFIX + PUBLISH_FORK_COUNT);
+    }
+
     public static GradleBuildContext createGradleContextFromMap(Map<String, Object> map) {
         Map<String, String> transformed = Maps.transformValues(map, new Function<Object, String>() {
             @Override
@@ -86,7 +91,7 @@ public class GradleBuildContext extends AbstractBuildContext {
                 RUN_LICENSE_CHECKS, PREFIX + LICENSE_VIOLATION_RECIPIENTS,
                 PREFIX + LIMIT_CHECKS_TO_THE_FOLLOWING_SCOPES, PREFIX + ENVIRONMENT_VARIABLES,
                 PREFIX + INCLUDE_PUBLISHED_ARTIFACTS, PREFIX + DISABLE_AUTOMATIC_LICENSE_DISCOVERY,
-                PUBLISH_ARTIFACTS_PARAM, PREFIX + PUBLISH_MAVEN_DESCRIPTORS_PARAM,
+                PUBLISH_ARTIFACTS_PARAM, PREFIX + PUBLISH_FORK_COUNT, PREFIX + PUBLISH_MAVEN_DESCRIPTORS_PARAM,
                 PREFIX + PUBLISH_IVY_DESCRIPTORS_PARAM, USE_M2_COMPATIBLE_PATTERNS_PARAM,
                 PREFIX + IVY_PATTERN_PARAM, PREFIX + JDK, PREFIX + ARTIFACT_PATTERN_PARAM,
                 PREFIX + PUBLISH_INCLUDE_PATTERNS_PARAM, PREFIX + PUBLISH_EXCLUDE_PATTERNS_PARAM,

--- a/src/main/resources/i18n-jfrog.properties
+++ b/src/main/resources/i18n-jfrog.properties
@@ -112,6 +112,8 @@ artifactory.task.gradle.useArtifactoryGradlePlugin.description = The Bamboo plug
                                                                  If your project applies the Artifactory plugin using a custom init script, make sure to include your init script as part of the list of Gradle switches.
 artifactory.task.gradle.publishArtifacts = Publish Artifacts to Artifactory
 artifactory.task.gradle.publishArtifacts.description = Check if you wish to publish produced build artifacts to Artifactory.
+artifactory.task.gradle.publishForkCount = Number of threads used to publish artifacts
+artifactory.task.gradle.publishForkCount.description = Change if you wish to use a different number of threads to publish artifacts.
 artifactory.task.gradle.publishMavenDescriptors = Publish Maven Descriptors
 artifactory.task.gradle.publishMavenDescriptors.description = Check if you wish to publish Gradle-generated POM files to Artifactory. Note: Maven descriptors are always deployed according to the Maven layout convention.
 artifactory.task.gradle.publishIvyDescriptors = Publish Ivy Descriptors

--- a/src/main/resources/templates/plugins/task/editArtifactoryGradleBuilder.ftl
+++ b/src/main/resources/templates/plugins/task/editArtifactoryGradleBuilder.ftl
@@ -75,6 +75,8 @@ listKey='repoKey' listValue='repoKey' toggle='true'/]
 
 [@ui.bambooSection dependsOn='publishArtifacts' showOn=true]
 
+    [@ww.textfield labelKey='artifactory.task.gradle.publishForkCount' name='builder.artifactoryGradleBuilder.publishForkCount' value='${publishForkCount}'/]
+
     [@ww.checkbox labelKey='artifactory.task.gradle.publishMavenDescriptors' name='builder.artifactoryGradleBuilder.publishMavenDescriptors' toggle='true'/]
 
     [@ww.checkbox labelKey='artifactory.task.gradle.publishIvyDescriptors' name='builder.artifactoryGradleBuilder.publishIvyDescriptors' toggle='true'/]

--- a/src/main/resources/templates/plugins/task/editArtifactoryGradleBuilder.ftl
+++ b/src/main/resources/templates/plugins/task/editArtifactoryGradleBuilder.ftl
@@ -75,7 +75,7 @@ listKey='repoKey' listValue='repoKey' toggle='true'/]
 
 [@ui.bambooSection dependsOn='publishArtifacts' showOn=true]
 
-    [@ww.textfield labelKey='artifactory.task.gradle.publishForkCount' name='builder.artifactoryGradleBuilder.publishForkCount' value='${publishForkCount}'/]
+    [@ww.select labelKey="artifactory.task.gradle.publishForkCount" name="builder.artifactoryGradleBuilder.publishForkCount" list="builder.artifactoryGradleBuilder.publishForkCountList" value='builder.artifactoryGradleBuilder.publishForkCount'/]
 
     [@ww.checkbox labelKey='artifactory.task.gradle.publishMavenDescriptors' name='builder.artifactoryGradleBuilder.publishMavenDescriptors' toggle='true'/]
 

--- a/src/main/resources/templates/plugins/task/viewArtifactoryGradleBuilder.ftl
+++ b/src/main/resources/templates/plugins/task/viewArtifactoryGradleBuilder.ftl
@@ -32,6 +32,7 @@
 
 [@ww.label labelKey='Publish Artifacts To Artifactory' name='builder.artifactoryGradleBuilder.publishArtifacts'/]
 [#if isPublishArtifacts]
+    [@ww.label labelKey='Publish fork count' name='builder.artifactoryGradleBuilder.publishForkCount'/]
     [@ww.label labelKey='Publish Maven Descriptors' name='builder.artifactoryGradleBuilder.publishMavenDescriptors'/]
     [@ww.label labelKey='Publish Ivy Descriptors' name='builder.artifactoryGradleBuilder.publishIvyDescriptors'/]
     [@ww.label labelKey='Use Maven 2 Compatible Patterns' name='builder.artifactoryGradleBuilder.useM2CompatiblePatterns'/]


### PR DESCRIPTION
With the new version of the build-info-extractor-gradle Gradle plugin, this PR upgrades the plugin version, and add a new field in the UI of the `view/editArtifactoryGradleBuilder` to override the default setting for the publishForkCount parameter.

Tested manually on Bamboo 6.9.2.