### PR TITLE
Fix Gradle task edit

### DIFF
--- a/src/main/java/org/jfrog/bamboo/configuration/ArtifactoryGradleConfiguration.java
+++ b/src/main/java/org/jfrog/bamboo/configuration/ArtifactoryGradleConfiguration.java
@@ -4,18 +4,14 @@ import com.atlassian.bamboo.collections.ActionParametersMap;
 import com.atlassian.bamboo.plan.Plan;
 import com.atlassian.bamboo.task.TaskDefinition;
 import com.atlassian.bamboo.v2.build.agent.capability.CapabilityDefaultsHelper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jfrog.bamboo.context.AbstractBuildContext;
 import org.jfrog.bamboo.context.GradleBuildContext;
 
-import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Configuration for {@link org.jfrog.bamboo.task.ArtifactoryGradleTask}
@@ -27,7 +23,6 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
     protected static final String DEFAULT_TEST_REPORTS_XML = "**/build/test-results/*.xml";
     private static final Set<String> FIELDS_TO_COPY = GradleBuildContext.getFieldsToCopy();
     private static final String PUBLISH_FORK_COUNT_OPTIONS_KEY = "publishForkCountList";
-    private static final List<Integer> PUBLISH_FORK_COUNT_OPTIONS = ImmutableList.of(1, 2, 4, 8);
     private static final String PUBLISH_FORK_COUNT_KEY = "publishForkCount";
 
     public ArtifactoryGradleConfiguration() {
@@ -52,8 +47,8 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
         context.put("builder.artifactoryGradleBuilder.gitReleaseBranch", "REL-BRANCH-");
         context.put("artifactory.vcs.git.vcs.type.list", getVcsTypes());
         context.put("artifactory.vcs.git.authenticationType.list", getGitAuthenticationTypes());
-        context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_OPTIONS_KEY, getPublishForkCountList());
-        context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_KEY, getDefaultPublishForkCount());
+        context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_OPTIONS_KEY, GradleBuildContext.getPublishForkCountList());
+        context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_KEY, GradleBuildContext.getDefaultPublishForkCount());
     }
 
     @Override
@@ -80,7 +75,7 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
         }
         context.put("artifactory.vcs.git.vcs.type.list", getVcsTypes());
         context.put("artifactory.vcs.git.authenticationType.list", getGitAuthenticationTypes());
-        context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_OPTIONS_KEY, getPublishForkCountList());
+        context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_OPTIONS_KEY, GradleBuildContext.getPublishForkCountList());
         context.put(GradleBuildContext.PREFIX + PUBLISH_FORK_COUNT_KEY, buildContext.getPublishForkCount());
     }
 
@@ -118,17 +113,5 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
     @Override
     public boolean taskProducesTestResults(@NotNull TaskDefinition definition) {
         return new GradleBuildContext(definition.getConfiguration()).isTestChecked();
-    }
-
-    private List<String> getPublishForkCountList() {
-        return PUBLISH_FORK_COUNT_OPTIONS.stream()
-                .map(String::valueOf)
-                .collect(Collectors.toList());
-    }
-
-    private String getDefaultPublishForkCount() {
-        return String.valueOf(PUBLISH_FORK_COUNT_OPTIONS.stream()
-                .mapToInt(v -> v)
-                .max().orElseThrow(NoSuchElementException::new));
     }
 }

--- a/src/main/java/org/jfrog/bamboo/context/GradleBuildContext.java
+++ b/src/main/java/org/jfrog/bamboo/context/GradleBuildContext.java
@@ -1,12 +1,17 @@
 package org.jfrog.bamboo.context;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang.StringUtils;
 import org.jfrog.bamboo.bintray.PushToBintrayContext;
 
+import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Tomer Cohen
@@ -20,6 +25,7 @@ public class GradleBuildContext extends AbstractBuildContext {
     public static final String USE_GRADLE_WRAPPER_PARAM = "useGradleWrapper";
     public static final String GRADLE_WRAPPER_LOCATION_PARAM = "gradleWrapperLocation";
     public static final String PUBLISH_FORK_COUNT_PARAM = "publishForkCount";
+    private static final List<Integer> PUBLISH_FORK_COUNT_OPTIONS = ImmutableList.of(1, 2, 4, 8);
 
     public GradleBuildContext(Map<String, String> env) {
         super(PREFIX, env);
@@ -62,7 +68,8 @@ public class GradleBuildContext extends AbstractBuildContext {
     }
 
     public int getPublishForkCount() {
-        return Integer.parseInt(env.get(PREFIX + PUBLISH_FORK_COUNT_PARAM));
+        String forkCount = env.get(PREFIX + PUBLISH_FORK_COUNT_PARAM);
+        return Integer.parseInt(StringUtils.isNotBlank(forkCount) ? (forkCount) : getDefaultPublishForkCount());
     }
 
     public static GradleBuildContext createGradleContextFromMap(Map<String, Object> map) {
@@ -114,5 +121,17 @@ public class GradleBuildContext extends AbstractBuildContext {
                 PREFIX + RUN_LICENSE_CHECKS, PREFIX + PUBLISH_ARTIFACTS_PARAM, PREFIX + TEST_CHECKED,
                 PREFIX + TEST_DIRECTORY_OPTION, PREFIX + ENABLE_RELEASE_MANAGEMENT,
                 PREFIX + USE_M2_COMPATIBLE_PATTERNS_PARAM);
+    }
+
+    public static List<String> getPublishForkCountList() {
+        return PUBLISH_FORK_COUNT_OPTIONS.stream()
+                .map(String::valueOf)
+                .collect(Collectors.toList());
+    }
+
+    public static String getDefaultPublishForkCount() {
+        return String.valueOf(PUBLISH_FORK_COUNT_OPTIONS.stream()
+                .mapToInt(v -> v)
+                .max().orElseThrow(NoSuchElementException::new));
     }
 }


### PR DESCRIPTION
Trying to edit an existing Gradle task fails with an exception thrown when trying to parse the fork count parameter which is blank.