### PR TITLE
Adapt to npm, nuget and dotnet changes in build-info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
         <!-- This plugin key is to be used as a unique ID of the plugin incl.
         version and not as a key regarding the Atlassian plugin descriptor -->
         <plugin.key>${project.groupId}.${project.artifactId}-${project.version}</plugin.key>
-        <buildinfo.version>2.20.0</buildinfo.version>
+        <buildinfo.version>2.21.x-SNAPSHOT</buildinfo.version>
         <buildinfo.maven.version>2.20.0</buildinfo.maven.version>
         <buildinfo.gradle.version>4.18.0</buildinfo.gradle.version>
         <buildinfo.ivy.version>2.20.0</buildinfo.ivy.version>
-        <buildinfo.npm.version>2.20.0</buildinfo.npm.version>
-        <buildinfo.nuget.version>2.20.0</buildinfo.nuget.version>
+        <buildinfo.npm.version>2.21.x-SNAPSHOT</buildinfo.npm.version>
+        <buildinfo.nuget.version>2.21.x-SNAPSHOT</buildinfo.nuget.version>
         <buildinfo.docker.version>2.20.0</buildinfo.docker.version>
     </properties>
 

--- a/src/main/java/org/jfrog/bamboo/task/ArtifactoryNpmTask.java
+++ b/src/main/java/org/jfrog/bamboo/task/ArtifactoryNpmTask.java
@@ -14,9 +14,11 @@ import org.jfrog.bamboo.configuration.BuildParamsOverrideManager;
 import org.jfrog.bamboo.context.NpmBuildContext;
 import org.jfrog.bamboo.util.BuildInfoLog;
 import org.jfrog.bamboo.util.TaskUtils;
+import org.jfrog.build.api.util.Log;
 import org.jfrog.build.api.Build;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryDependenciesClientBuilder;
-import org.jfrog.build.extractor.npm.extractor.NpmInstall;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryBuildInfoClientBuilder;
+import org.jfrog.build.extractor.npm.extractor.NpmInstallCi;
 import org.jfrog.build.extractor.npm.extractor.NpmPublish;
 
 import java.io.File;
@@ -112,9 +114,12 @@ public class ArtifactoryNpmTask extends ArtifactoryTaskType {
      * @return Build containing affected artifacts, null if execution failed.
      */
     private Build executeNpmInstall() {
-        ArtifactoryDependenciesClientBuilder clientBuilder = TaskUtils.getArtifactoryDependenciesClientBuilder(buildInfoHelper.getServerConfig(), new BuildInfoLog(log, logger));
+        ServerConfig serverConfig = buildInfoHelper.getServerConfig();
+        Log buildInfoLogger = new BuildInfoLog(log, logger);
+        ArtifactoryDependenciesClientBuilder depsClientBuilder = TaskUtils.getArtifactoryDependenciesClientBuilder(serverConfig, buildInfoLogger);
+        ArtifactoryBuildInfoClientBuilder buildInfoClientBuilder = TaskUtils.getArtifactoryBuildInfoClientBuilder(serverConfig, buildInfoLogger);
         String repo = buildInfoHelper.overrideParam(npmBuildContext.getResolutionRepo(), BuildParamsOverrideManager.OVERRIDE_ARTIFACTORY_RESOLVE_REPO);
-        return new NpmInstall(clientBuilder, repo, npmBuildContext.getArguments(), buildInfoLog, packagePath, environmentVariables, "").execute();
+        return new NpmInstallCi(depsClientBuilder, buildInfoClientBuilder, repo, npmBuildContext.getArguments(), buildInfoLog, packagePath, environmentVariables, "", buildName, false).execute();
     }
 
     /**


### PR DESCRIPTION
This PR was opened to include include the changes made in https://github.com/jfrog/build-info/pull/420 in the bamboo-artifactory-plugin. The additional log print may help pinpoint the issue reported in https://github.com/jfrog/bamboo-artifactory-plugin/issues/112.

In addition, this PR adapts to the NPM changes added in the build-info depedency.
