### PR TITLE
Skip integration tests by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ brew install atlassian/tap/atlassian-plugin-sdk
 ### Running the integration tests
 To run the integration tests, execute the following command:
 ```shell script
-atlas-clean && atlas-integration-test
+atlas-clean && atlas-integration-test -DskipITs=false
 ```
 
 ### Running a single test

--- a/ci/pipelines.tests.yml
+++ b/ci/pipelines.tests.yml
@@ -49,7 +49,7 @@ pipelines:
             - atlas-version
 
             # Run integration tests
-            - atlas-integration-test -B
+            - atlas-integration-test -B -DskipITs=false
           onComplete:
             # Show tests in the *Tests* tab
             - save_tests $res_bambooGit_resourcePath/target/group-it/tomcat85x/surefire-reports/

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
+        <skipITs>true</skipITs>
         <buildinfo.version>2.21.x-SNAPSHOT</buildinfo.version>
         <buildinfo.maven.version>2.21.x-SNAPSHOT</buildinfo.maven.version>
         <buildinfo.gradle.version>4.18.x-SNAPSHOT</buildinfo.gradle.version>


### PR DESCRIPTION
Avoid triggering integration test running `mvn install`.

To run the integration tests, run:
```
atlas-integration-test -DskipITs=false
```