### PR TITLE
Bug fix - Passwords with special characters cannot be used in tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,15 +57,9 @@
             <id>oss</id>
             <repositories>
                 <repository>
-                    <id>central</id>
+                    <id>oss-releases</id>
                     <name>jfrog-dependencies</name>
-                    <url>http://oss.jfrog.org/artifactory/jfrog-dependencies</url>
-                </repository>
-                <repository>
-                    <snapshots/>
-                    <id>snapshots</id>
-                    <name>libs-snapshot</name>
-                    <url>http://oss.jfrog.org/artifactory/libs-snapshot</url>
+                    <url>https://releases.jfrog.io/artifactory/oss-releases</url>
                 </repository>
                 <repository>
                     <id>atlassian-public</id>
@@ -73,20 +67,6 @@
                 </repository>
             </repositories>
             <pluginRepositories>
-                <pluginRepository>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                    <id>central</id>
-                    <name>jfrog-dependencies</name>
-                    <url>http://oss.jfrog.org/artifactory/jfrog-dependencies</url>
-                </pluginRepository>
-                <pluginRepository>
-                    <snapshots/>
-                    <id>snapshots</id>
-                    <name>plugins-snapshot</name>
-                    <url>http://oss.jfrog.org/artifactory/plugins-snapshot</url>
-                </pluginRepository>
                 <pluginRepository>
                     <id>atlassian-public</id>
                     <url>https://maven.atlassian.com/repository/public</url>

--- a/src/main/java/org/jfrog/bamboo/admin/ArtifactoryServerConfigAction.java
+++ b/src/main/java/org/jfrog/bamboo/admin/ArtifactoryServerConfigAction.java
@@ -101,11 +101,11 @@ public class ArtifactoryServerConfigAction extends BambooActionSupport implement
 
     public String doUpdate() throws Exception {
         // Decrypt password from UI, if encrypted.
-        password = EncryptionHelper.decodeAndDecryptIfNeeded(password);
+        password = EncryptionHelper.decryptIfNeeded(password);
         if (isTesting()) {
             testConnection();
             // Encrypt password when returning it to UI.
-            password = EncryptionHelper.encryptAndEncode(password);
+            password = EncryptionHelper.encryptForUi(password);
             return INPUT;
         }
         serverConfigManager.updateServerConfiguration(createServerConfig());
@@ -229,7 +229,7 @@ public class ArtifactoryServerConfigAction extends BambooActionSupport implement
     private void updateFieldsFromServerConfig(ServerConfig serverConfig) {
         setUrl(serverConfig.getUrl());
         setUsername(serverConfig.getUsername());
-        setPassword(EncryptionHelper.encryptAndEncode(serverConfig.getPassword()));
+        setPassword(EncryptionHelper.encryptForUi(serverConfig.getPassword()));
         setTimeout(serverConfig.getTimeout());
     }
 

--- a/src/main/java/org/jfrog/bamboo/admin/ServerConfigManager.java
+++ b/src/main/java/org/jfrog/bamboo/admin/ServerConfigManager.java
@@ -273,7 +273,7 @@ public class ServerConfigManager implements Serializable {
 
         for (ServerConfig serverConfig : configuredServers) {
             serverConfigs.add(new ServerConfig(serverConfig.getId(), serverConfig.getUrl(), serverConfig.getUsername(),
-                    EncryptionHelper.encrypt(serverConfig.getPassword(), true), serverConfig.getTimeout()));
+                    EncryptionHelper.encryptForConfig(serverConfig.getPassword()), serverConfig.getTimeout()));
         }
         String serverConfigsString = toXMLString(serverConfigs);
         bandanaManager.setValue(PlanAwareBandanaContext.GLOBAL_CONTEXT, ARTIFACTORY_CONFIG_KEY, serverConfigsString);

--- a/src/main/java/org/jfrog/bamboo/configuration/AbstractArtifactoryConfiguration.java
+++ b/src/main/java/org/jfrog/bamboo/configuration/AbstractArtifactoryConfiguration.java
@@ -229,7 +229,7 @@ public abstract class AbstractArtifactoryConfiguration extends AbstractTaskConfi
     }
 
     private boolean isEncrypted(String value) {
-        String decryptedValue = EncryptionHelper.decodeAndDecryptIfNeeded(value);
+        String decryptedValue = EncryptionHelper.decryptIfNeeded(value);
         return !decryptedValue.equals(value);
     }
 
@@ -248,10 +248,10 @@ public abstract class AbstractArtifactoryConfiguration extends AbstractTaskConfi
             if (shouldEncrypt(key)) {
                 String value = entry.getValue();
                 if (isEncrypted(value)) {
-                    value = EncryptionHelper.decodeAndDecryptIfNeeded(value);
+                    value = EncryptionHelper.decryptIfNeeded(value);
                 }
                 if (enc) {
-                    value = EncryptionHelper.encryptAndEncode(value);
+                    value = EncryptionHelper.encryptForUi(value);
                 }
                 entry.setValue(value);
             }

--- a/src/main/java/org/jfrog/bamboo/security/EncryptionHelper.java
+++ b/src/main/java/org/jfrog/bamboo/security/EncryptionHelper.java
@@ -32,7 +32,7 @@ public class EncryptionHelper {
     private static final String dbKey = "Beetlejuice version $version (c) Copyright 2003-2005 Pols Consulting Limited";
 
     /***
-     * Encrypts data with the constant DB key. Use this method to encrypt configuration data. For example, sensetive data which is meant
+     * Encrypts data with the constant DB key. Use this method to encrypt configuration data. For example, sensitive data which is meant
      * to be saved to the DB.
      * Use the 'decrypt' method for the opposite operation.
      * @param stringToEncrypt - Nullable string to encrypt.
@@ -53,7 +53,7 @@ public class EncryptionHelper {
     }
 
     /***
-     * Encrypts data with the changing genetated key. Use this method to encrypt sensetive data before it is presented in the UI.
+     * Encrypts data with the changing generated key. Use this method to encrypt sensitive data before it is presented in the UI.
      * Use the 'decrypt' method for the opposite operation.
      * @param stringToEncrypt - Nullable string to encrypt.
      * @return - Encrypted data.


### PR DESCRIPTION
This PR fixes the following bug:
If you set a task with the "Username and password" option, and the password you set includes special characters, such as %, the tasl will fail when executed with "401 Unauthorised".