### PR TITLE
Bug#148 -

### DIFF
--- a/src/main/java/org/jfrog/bamboo/builder/BuilderDependencyHelper.java
+++ b/src/main/java/org/jfrog/bamboo/builder/BuilderDependencyHelper.java
@@ -58,7 +58,11 @@ public class BuilderDependencyHelper implements Serializable {
         }
 
         //Search for older plugin dirs and remove if any exist
-        for (File buildDirChild : planTemp.listFiles()) {
+        File[] planTempFiles = planTemp.listFiles();
+        if(planTempFiles == null ) {
+            planTempFiles = new File[0];
+        }
+        for (File buildDirChild : planTempFiles) {
             String buildDirChildName = buildDirChild.getName();
             if (buildDirChildName.startsWith(pluginDescriptorKey) &&
                     (!buildDirChildName.equals(pluginKey) || buildDirChildName.endsWith("-SNAPSHOT"))) {
@@ -66,6 +70,7 @@ public class BuilderDependencyHelper implements Serializable {
                 buildDirChild.delete();
             }
         }
+
 
         File pluginDir = new File(planTemp, pluginKey);
         File builderDependencyDir = new File(pluginDir, builderKey);


### PR DESCRIPTION
Fix NullPointerException for BuilderDependencyHelper due to the use of Files.listFiles methond in downloadDependenciesAndGetPath method inside a for loop making it unpredictable