### PR TITLE
Bug#148 -

### DIFF
--- a/src/main/java/org/jfrog/bamboo/builder/BuilderDependencyHelper.java
+++ b/src/main/java/org/jfrog/bamboo/builder/BuilderDependencyHelper.java
@@ -58,12 +58,15 @@ public class BuilderDependencyHelper implements Serializable {
         }
 
         //Search for older plugin dirs and remove if any exist
-        for (File buildDirChild : planTemp.listFiles()) {
-            String buildDirChildName = buildDirChild.getName();
-            if (buildDirChildName.startsWith(pluginDescriptorKey) &&
-                    (!buildDirChildName.equals(pluginKey) || buildDirChildName.endsWith("-SNAPSHOT"))) {
-                FileUtils.deleteQuietly(buildDirChild);
-                buildDirChild.delete();
+        File[] planTempFiles = planTemp.listFiles();
+        if (null !=  planTempFiles) {
+            for (File buildDirChild : planTempFiles) {
+                String buildDirChildName = buildDirChild.getName();
+                if (buildDirChildName.startsWith(pluginDescriptorKey) &&
+                        (!buildDirChildName.equals(pluginKey) || buildDirChildName.endsWith("-SNAPSHOT"))) {
+                    FileUtils.deleteQuietly(buildDirChild);
+                    buildDirChild.delete();
+                }
             }
         }
 

--- a/src/test/java/org/jfrog/bamboo/builder/BuilderDependencyHelperTest.java
+++ b/src/test/java/org/jfrog/bamboo/builder/BuilderDependencyHelperTest.java
@@ -1,0 +1,26 @@
+package org.jfrog.bamboo.builder;
+
+import org.apache.commons.collections.map.HashedMap;
+import org.jfrog.bamboo.context.Maven3BuildContext;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class BuilderDependencyHelperTest {
+
+    private BuilderDependencyHelper builderDependencyHelper;
+
+    @Test
+    public void shouldNotThrowExceptionForEmptyTempDir() throws IOException {
+        builderDependencyHelper = new BuilderDependencyHelper("artifactoryBuilderTest");
+        builderDependencyHelper.downloadDependenciesAndGetPath( new File(""), "TEST-ART-BAMB",new Maven3BuildContext(new HashedMap()),"something" );
+    }
+
+    @Test
+    public void shouldNotThrowExceptionForNullTemp() throws IOException {
+        builderDependencyHelper = new BuilderDependencyHelper("artifactoryBuilderTest");
+        builderDependencyHelper.downloadDependenciesAndGetPath( null, "TEST-ART-BAMB",new Maven3BuildContext(new HashedMap()),"something" );
+    }
+}


### PR DESCRIPTION
Fix NullPointerException for BuilderDependencyHelper as the use of Files.listFiles call in downloadDependenciesAndGetPath method inside a for loop was making it unpredictable and throwing NPE if temp dir is empty , incorrect or gets cleaned up .