### PR TITLE
Fix NullPointerException in BuilderDependencyHelper

### DIFF
--- a/src/main/java/org/jfrog/bamboo/builder/BuilderDependencyHelper.java
+++ b/src/main/java/org/jfrog/bamboo/builder/BuilderDependencyHelper.java
@@ -59,7 +59,7 @@ public class BuilderDependencyHelper implements Serializable {
 
         //Search for older plugin dirs and remove if any exist
         File[] planTempFiles = planTemp.listFiles();
-        if (null !=  planTempFiles) {
+        if (null != planTempFiles) {
             for (File buildDirChild : planTempFiles) {
                 String buildDirChildName = buildDirChild.getName();
                 if (buildDirChildName.startsWith(pluginDescriptorKey) &&

--- a/src/main/java/org/jfrog/bamboo/builder/BuilderDependencyHelper.java
+++ b/src/main/java/org/jfrog/bamboo/builder/BuilderDependencyHelper.java
@@ -58,12 +58,15 @@ public class BuilderDependencyHelper implements Serializable {
         }
 
         //Search for older plugin dirs and remove if any exist
-        for (File buildDirChild : planTemp.listFiles()) {
-            String buildDirChildName = buildDirChild.getName();
-            if (buildDirChildName.startsWith(pluginDescriptorKey) &&
-                    (!buildDirChildName.equals(pluginKey) || buildDirChildName.endsWith("-SNAPSHOT"))) {
-                FileUtils.deleteQuietly(buildDirChild);
-                buildDirChild.delete();
+        File[] planTempFiles = planTemp.listFiles();
+        if (null !=  planTempFiles) {
+            for (File buildDirChild : planTempFiles) {
+                String buildDirChildName = buildDirChild.getName();
+                if (buildDirChildName.startsWith(pluginDescriptorKey) &&
+                        (!buildDirChildName.equals(pluginKey) || buildDirChildName.endsWith("-SNAPSHOT"))) {
+                    FileUtils.deleteQuietly(buildDirChild);
+                    buildDirChild.delete();
+                }
             }
         }
 

--- a/src/test/java/org/jfrog/bamboo/builder/BuilderDependencyHelperTest.java
+++ b/src/test/java/org/jfrog/bamboo/builder/BuilderDependencyHelperTest.java
@@ -15,12 +15,12 @@ public class BuilderDependencyHelperTest {
     @Test
     public void shouldNotThrowExceptionForEmptyTempDir() throws IOException {
         builderDependencyHelper = new BuilderDependencyHelper("artifactoryBuilderTest");
-        builderDependencyHelper.downloadDependenciesAndGetPath( new File(""), "TEST-ART-BAMB", new Maven3BuildContext(new HashMap<>()), "something" );
+        builderDependencyHelper.downloadDependenciesAndGetPath(new File(""), "TEST-ART-BAMB", new Maven3BuildContext(new HashMap<>()), "something");
     }
 
     @Test
     public void shouldNotThrowExceptionForNullTemp() throws IOException {
         builderDependencyHelper = new BuilderDependencyHelper("artifactoryBuilderTest");
-        builderDependencyHelper.downloadDependenciesAndGetPath( null, "TEST-ART-BAMB", new Maven3BuildContext(new HashMap<>()), "something" );
+        builderDependencyHelper.downloadDependenciesAndGetPath(null, "TEST-ART-BAMB", new Maven3BuildContext(new HashMap<>()), "something");
     }
 }

--- a/src/test/java/org/jfrog/bamboo/builder/BuilderDependencyHelperTest.java
+++ b/src/test/java/org/jfrog/bamboo/builder/BuilderDependencyHelperTest.java
@@ -1,11 +1,11 @@
 package org.jfrog.bamboo.builder;
 
-import org.apache.commons.collections.map.HashedMap;
 import org.jfrog.bamboo.context.Maven3BuildContext;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 
 
 public class BuilderDependencyHelperTest {
@@ -15,12 +15,12 @@ public class BuilderDependencyHelperTest {
     @Test
     public void shouldNotThrowExceptionForEmptyTempDir() throws IOException {
         builderDependencyHelper = new BuilderDependencyHelper("artifactoryBuilderTest");
-        builderDependencyHelper.downloadDependenciesAndGetPath( new File(""), "TEST-ART-BAMB",new Maven3BuildContext(new HashedMap()),"something" );
+        builderDependencyHelper.downloadDependenciesAndGetPath( new File(""), "TEST-ART-BAMB", new Maven3BuildContext(new HashMap<>()), "something" );
     }
 
     @Test
     public void shouldNotThrowExceptionForNullTemp() throws IOException {
         builderDependencyHelper = new BuilderDependencyHelper("artifactoryBuilderTest");
-        builderDependencyHelper.downloadDependenciesAndGetPath( null, "TEST-ART-BAMB",new Maven3BuildContext(new HashedMap()),"something" );
+        builderDependencyHelper.downloadDependenciesAndGetPath( null, "TEST-ART-BAMB", new Maven3BuildContext(new HashMap<>()), "something" );
     }
 }

--- a/src/test/java/org/jfrog/bamboo/builder/BuilderDependencyHelperTest.java
+++ b/src/test/java/org/jfrog/bamboo/builder/BuilderDependencyHelperTest.java
@@ -1,0 +1,26 @@
+package org.jfrog.bamboo.builder;
+
+import org.apache.commons.collections.map.HashedMap;
+import org.jfrog.bamboo.context.Maven3BuildContext;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class BuilderDependencyHelperTest {
+
+    private BuilderDependencyHelper builderDependencyHelper;
+
+    @Test
+    public void shouldNotThrowExceptionForEmptyTempDir() throws IOException {
+        builderDependencyHelper = new BuilderDependencyHelper("artifactoryBuilderTest");
+        builderDependencyHelper.downloadDependenciesAndGetPath( new File(""), "TEST-ART-BAMB",new Maven3BuildContext(new HashedMap()),"something" );
+    }
+
+    @Test
+    public void shouldNotThrowExceptionForNullTemp() throws IOException {
+        builderDependencyHelper = new BuilderDependencyHelper("artifactoryBuilderTest");
+        builderDependencyHelper.downloadDependenciesAndGetPath( null, "TEST-ART-BAMB",new Maven3BuildContext(new HashedMap()),"something" );
+    }
+}


### PR DESCRIPTION
Fix NullPointerException for BuilderDependencyHelper as the use of Files.listFiles call in downloadDependenciesAndGetPath method inside a for loop was making it unpredictable and throwing NPE if temp dir is empty , incorrect or gets cleaned up .