### PR TITLE
NPE in Maven when no deployment server configured

### DIFF
--- a/src/main/java/org/jfrog/bamboo/builder/MavenDataHelper.java
+++ b/src/main/java/org/jfrog/bamboo/builder/MavenDataHelper.java
@@ -90,7 +90,7 @@ public class MavenDataHelper extends MavenAndIvyBuildInfoDataHelperBase {
         ServerConfig overriderServerConfig = TaskUtils.getResolutionServerConfig(
                 buildContext.getOverriddenUsername(runtimeContext, buildInfoLog, false),
                 buildContext.getOverriddenPassword(runtimeContext, buildInfoLog, false),
-                serverConfigManager, selectedServerConfig, buildParamsOverrideManager);
+                serverConfigManager, resolutionServerConfig, buildParamsOverrideManager);
         resolverUrl = resolutionServerConfig.getUrl();
         resolverUsername = overriderServerConfig.getUsername();
         resolverPassword = overriderServerConfig.getPassword();


### PR DESCRIPTION
setResolverProperties is using the deployment server details instead of the resolution server details.