### PR TITLE
Split large Build Info content to chunks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.jfrog.testing</groupId>
             <artifactId>jfrog-testing-infra</artifactId>
             <version>1.0.2</version>

--- a/src/main/java/org/jfrog/bamboo/util/TaskUtils.java
+++ b/src/main/java/org/jfrog/bamboo/util/TaskUtils.java
@@ -49,7 +49,7 @@ import static org.jfrog.bamboo.util.ConstantValues.AGGREGATED_BUILD_INFO;
 public class TaskUtils {
     // Bamboo's buildData variable size is limited by the size of an environment variable in the operating system.
     // This variable limits the size of a buildData variable.
-    private static final int MAX_BUILD_DATA_SIZE = 16384;
+    private static final int MAX_BUILD_DATA_SIZE = 2047;
 
     /**
      * Get an escaped version of the environment map that is to be passed onwards to the extractors. Bamboo escapes the

--- a/src/test/java/org/jfrog/bamboo/utils/TaskUtilsTest.java
+++ b/src/test/java/org/jfrog/bamboo/utils/TaskUtilsTest.java
@@ -1,0 +1,87 @@
+package org.jfrog.bamboo.utils;
+
+import com.atlassian.bamboo.task.TaskContext;
+import com.atlassian.bamboo.v2.build.BuildContext;
+import com.atlassian.bamboo.v2.build.CurrentBuildResult;
+import org.jfrog.build.api.Build;
+import org.jfrog.build.api.Dependency;
+import org.jfrog.build.api.Module;
+import org.jfrog.build.api.builder.BuildInfoBuilder;
+import org.jfrog.build.api.builder.DependencyBuilder;
+import org.jfrog.build.api.builder.ModuleBuilder;
+import org.jfrog.build.extractor.BuildInfoExtractorUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.jfrog.bamboo.util.TaskUtils.addBuildInfoToContext;
+import static org.jfrog.bamboo.util.TaskUtils.getAndDeleteAggregatedBuildInfo;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author yahavi
+ **/
+public class TaskUtilsTest {
+    private Map<String, String> customBuildData;
+    private AutoCloseable mocks;
+
+    @Mock
+    CurrentBuildResult buildResult;
+    @Mock
+    BuildContext buildContext;
+    @Mock
+    TaskContext taskContext;
+
+    @Before
+    public void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+        customBuildData = new HashMap<>();
+        when(taskContext.getBuildContext()).thenReturn(buildContext);
+        when(buildContext.getParentBuildContext()).thenReturn(buildContext);
+        when(buildContext.getBuildResult()).thenReturn(buildResult);
+        when(buildResult.getCustomBuildData()).thenReturn(customBuildData);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mocks.close();
+    }
+
+    @Test
+    public void TestAddBuildInfoToContextOneDependency() throws IOException {
+        List<Dependency> dependencyList = new ArrayList<>();
+        dependencyList.add(new DependencyBuilder().id("a:b:c").build());
+        testAddBuildInfoToContext(dependencyList);
+    }
+
+    @Test
+    public void TestAddBuildInfoToContextManyDependencies() throws IOException {
+        List<Dependency> dependencyList = new ArrayList<>();
+        for (int i = 0; i < 100000; i++) {
+            dependencyList.add(new DependencyBuilder().id(String.valueOf(i)).build());
+        }
+        testAddBuildInfoToContext(dependencyList);
+    }
+
+    private void testAddBuildInfoToContext(List<Dependency> dependencyList) throws IOException {
+        // Create a build info with the input dependencies
+        Module module = new ModuleBuilder().id("test-module").dependencies(dependencyList).build();
+        Build build = new BuildInfoBuilder("test-build").number("1").started(new Date().toString()).addModule(module).build();
+        String expectedBuildInfo = BuildInfoExtractorUtils.buildInfoToJsonString(build);
+
+        // Run addBuildInfoToContext
+        addBuildInfoToContext(taskContext, expectedBuildInfo);
+
+        // Run getAndDeleteAggregatedBuildInfo and make sure the actual Build Info equals to the expected
+        assertEquals(expectedBuildInfo, getAndDeleteAggregatedBuildInfo(taskContext));
+
+        // Make sure that all buildData variables deleted
+        assertEquals(new HashMap<>(), customBuildData);
+    }
+}


### PR DESCRIPTION
Resolves #178

Currently, the Build Info is stored and aggregated in a single buildData variable. This variable stored in an environment variable eventually. To make sure it doesn't reach the max size limitation, this PR suggests splitting this variable into many variables.