### PR TITLE
Bugfix - Gradle wrapper should remove the requirement for capability

### DIFF
--- a/src/main/java/org/jfrog/bamboo/configuration/AbstractArtifactoryConfiguration.java
+++ b/src/main/java/org/jfrog/bamboo/configuration/AbstractArtifactoryConfiguration.java
@@ -157,12 +157,24 @@ public abstract class AbstractArtifactoryConfiguration extends AbstractTaskConfi
         if (StringUtils.isNotBlank(builderContextPrefix)) {
             taskConfiguratorHelper.addJdkRequirement(requirements, taskDefinition,
                     builderContextPrefix + TaskConfigConstants.CFG_JDK_LABEL);
-            if (StringUtils.isNotBlank(capabilityPrefix)) {
-                taskConfiguratorHelper.addSystemRequirementFromConfiguration(requirements, taskDefinition,
-                        builderContextPrefix + PackageManagersContext.EXECUTABLE, capabilityPrefix);
+            if (!isUseWrapper(taskDefinition)) {
+                if (StringUtils.isNotBlank(capabilityPrefix)) {
+                    taskConfiguratorHelper.addSystemRequirementFromConfiguration(requirements, taskDefinition,
+                            builderContextPrefix + PackageManagersContext.EXECUTABLE, capabilityPrefix);
+                }
             }
         }
         return requirements;
+    }
+
+    /**
+     * Return true if the task uses a wrapper. Using a wrapper should remove the requirement capability.
+     *
+     * @param taskDefinition - The task definition
+     * @return if the task uses a wrapper.
+     */
+    protected boolean isUseWrapper(TaskDefinition taskDefinition) {
+        return false;
     }
 
     protected void populateContextWithConfiguration(@NotNull Map<String, Object> context,

--- a/src/main/java/org/jfrog/bamboo/configuration/ArtifactoryGradleConfiguration.java
+++ b/src/main/java/org/jfrog/bamboo/configuration/ArtifactoryGradleConfiguration.java
@@ -153,4 +153,9 @@ public class ArtifactoryGradleConfiguration extends AbstractArtifactoryConfigura
         // Validate build name and number.
         TaskConfigurationValidations.validateCaptureBuildInfoParams(ArtifactoryBuildContext.BUILD_NAME, ArtifactoryBuildContext.BUILD_NUMBER, GradleBuildContext.CAPTURE_BUILD_INFO, params, errorCollection);
     }
+
+    @Override
+    protected boolean isUseWrapper(TaskDefinition taskDefinition) {
+        return Boolean.parseBoolean(taskDefinition.getConfiguration().get(GradleBuildContext.PREFIX + GradleBuildContext.USE_GRADLE_WRAPPER_PARAM));
+    }
 }


### PR DESCRIPTION
Currently, new Gradle jobs require Gradle capability. This PR removes this requirement when users select the "Use Gradle Wrapper" option.