### PR TITLE
Add Conditional Maven Deploy Goal Based on Bamboo Properties File

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,17 @@
                     <url>https://releases.jfrog.io/artifactory/oss-releases</url>
                 </repository>
                 <repository>
-                    <id>atlassian-public</id>
-                    <url>https://maven.atlassian.com/repository/public</url>
+                    <id>maven-atlassian-all</id>
+                    <url>https://packages.atlassian.com/mvn/maven-atlassian-all/</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>warn</checksumPolicy>
+                    </snapshots>
+                    <releases>
+                        <enabled>true</enabled>
+                        <checksumPolicy>warn</checksumPolicy>
+                    </releases>
                 </repository>
             </repositories>
             <pluginRepositories>


### PR DESCRIPTION
### Summary
This pull request introduces a new feature in the **Artifactory Bamboo Plugin** to conditionally append the Maven `deploy` goal based on a configuration property.

### Changes
1. **New `appendDeployGoalIfNeeded` Method**:
   - Reads a Bamboo properties file (`artifactory.bamboo.plugin.properties`) to determine if the `deploy` goal should always be appended to Maven arguments.
   - Supports both Bamboo Agent and Server environments for locating the properties file.
   - Ensures no duplicate `deploy` goal is appended.

2. **New `findPropertiesFile` Method**:
   - Dynamically searches for the properties file in multiple locations:
     - `BAMBOO_AGENT_HOME`
     - `bamboo.home` system property
     - `BAMBOO_HOME` environment variable.

3. **Integration with `appendGoals` Method**:
   - Calls the new `appendDeployGoalIfNeeded` method to conditionally add the `deploy` goal during the Maven build process.